### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "main": "lib/index.js",
   "dependencies": {},
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "devDependencies": {}
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
