### PR TITLE
Use Object.defineProperty not __defineGetter__

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,8 +88,10 @@
     return Object.keys(this)[i];
   };
 
-  Storage.prototype.__defineGetter__('length', function () {
-    return Object.keys(this).length;
+  Object.defineProperty(Storage.prototype, 'length', {
+    get: function() {
+      return Object.keys(this).length;
+    }
   });
 
   Storage.prototype.___save___ = function () {


### PR DESCRIPTION
This allows this library to be used in IE9/IE10.

This fixes issue #4.
